### PR TITLE
Chore: Use GitHub license template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -187,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2019-21 SAP SE or an SAP affiliate company.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -200,31 +199,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-------------------------------------------------------------------------------
-APIs
-
-This project may include APIs to SAP or third party products or services. The use of these APIs, products and services may be subject to additional agreements. In no event shall the application of the Apache Software License, v.2 to this project grant any rights in or to these APIs, products or services that would alter, expand, be inconsistent with, or supersede any terms of these additional agreements. “API” means application programming interfaces, as well as their respective specifications and implementing code that allows other software products to communicate with or call on SAP or third party products or services (for example, SAP Enterprise Services, BAPIs, Idocs, RFCs and ABAP calls or other user exits) and may be made available through SAP or third party products, SDKs, documentation or other media. 
-
-------------------------------------------------------------------------------
-SUBCOMPONENTS
-
-
-[****NOTE: Use this section to identify third party components or code snippets that are included in the project. This is for embedded components, not dependencies or prerequisites that must be obtained by users from third party sources outside of the project. If you have any questions please contact the Industry Standards and Open Source Team. Please delete this note prior to publication] 
-
-This project includes the following subcomponents that are subject to separate license terms. 
-Your use of these subcomponents is subject to the separate license terms applicable to
-each subcomponent.
-
-[****NOTE: List all third party components included in the project. Do not include the license text for these components here. License text should be included in the subsequent section. Please delete this note prior to publication]
- 
-Component: [****name and versions]
-Licensor: [****licensor/author]
-Website: [****website]
-License: [****license]
-Additional Notices: [****Include any additional notices here. This can include owner or copyright year listed in MIT and BSD licenses, subcomponent notices listed at the end of the LICENSE file in Apache licensed components, notices contained in the NOTICE file in Apache licensed components, or other notices.] 
-
-------------------------------------------------------------------------------
-
-[****Note: Use this section to include a single copy of each unique subcomponent license referenced in the previous section. For example, if there are three MIT licensed subcomponents then only publish the MIT license once. If there are Apache Software License subcomponents do not publish the Apache Software License in this section since it is already published above. Please delete this note prior to publication
-------------------------------------------------------------------------------


### PR DESCRIPTION
In order to be able to identify the main license of all managed repositories centrally, the SAP Open Source Program Office (OSPO) asks all teams to have an identifiable license in their repositories. For some reason (probably formatting - we usually have these issues with licenses copied via the [REUSE tool](https://reuse.software), but it also happens with older license templates) the [license in this repository is not detected properly by GitHub](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/licensing-a-repository#detecting-a-license). This PR includes text from a [GitHub license template](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository) that should facilitate the automated license detection.