### PR TITLE
Fix URLs and `brew audit` output

### DIFF
--- a/Casks/sapmachine11-ea-jdk.rb
+++ b/Casks/sapmachine11-ea-jdk.rb
@@ -2,15 +2,18 @@ cask "sapmachine11-ea-jdk" do
   version "11.0.16,4"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "c6354897bde429172a60e2e5455baef4804ce92fd37a1a791ced9dba5d06b8d1"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "624f5ebefbb471aef395eeaf7ead75cc17f9a8859c9666d5e83aa7a83af7449c"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"

--- a/Casks/sapmachine11-ea-jdk.rb
+++ b/Casks/sapmachine11-ea-jdk.rb
@@ -1,20 +1,19 @@
-
-cask 'sapmachine11-ea-jdk' do
-  version '11.0.16,4'
+cask "sapmachine11-ea-jdk" do
+  version "11.0.16,4"
 
   if Hardware::CPU.intel?
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
-    sha256 'c6354897bde429172a60e2e5455baef4804ce92fd37a1a791ced9dba5d06b8d1'
+    sha256 "c6354897bde429172a60e2e5455baef4804ce92fd37a1a791ced9dba5d06b8d1"
   else
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
-    sha256 '624f5ebefbb471aef395eeaf7ead75cc17f9a8859c9666d5e83aa7a83af7449c'
+    sha256 "624f5ebefbb471aef395eeaf7ead75cc17f9a8859c9666d5e83aa7a83af7449c"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine11-ea-jre.rb
+++ b/Casks/sapmachine11-ea-jre.rb
@@ -1,20 +1,19 @@
-
-cask 'sapmachine11-ea-jre' do
-  version '11.0.16,4'
+cask "sapmachine11-ea-jre" do
+  version "11.0.16,4"
 
   if Hardware::CPU.intel?
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
-    sha256 '378e2309f70be6bb308f50f5d7657629930ab1689357d2cb9efb5cde15508cde'
+    sha256 "378e2309f70be6bb308f50f5d7657629930ab1689357d2cb9efb5cde15508cde"
   else
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
-    sha256 '77d1ff6102fd280a581da23e0b3a1fc09db32aafcfb870e6127760e8e6ce659b'
+    sha256 "77d1ff6102fd280a581da23e0b3a1fc09db32aafcfb870e6127760e8e6ce659b"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine11-ea-jre.rb
+++ b/Casks/sapmachine11-ea-jre.rb
@@ -2,15 +2,18 @@ cask "sapmachine11-ea-jre" do
   version "11.0.16,4"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "378e2309f70be6bb308f50f5d7657629930ab1689357d2cb9efb5cde15508cde"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "77d1ff6102fd280a581da23e0b3a1fc09db32aafcfb870e6127760e8e6ce659b"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"

--- a/Casks/sapmachine11-jdk.rb
+++ b/Casks/sapmachine11-jdk.rb
@@ -1,14 +1,13 @@
-
-cask 'sapmachine11-jdk' do
-  version '11.0.15.0.1'
-  sha256 '3f61d992efc8bf53d56338a4b1ae0e00ff5ee3ef8c449a2c563de81cbbf0b336'
+cask "sapmachine11-jdk" do
+  version "11.0.15.0.1"
+  sha256 "3f61d992efc8bf53d56338a4b1ae0e00ff5ee3ef8c449a2c563de81cbbf0b336"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine11-jdk.rb
+++ b/Casks/sapmachine11-jdk.rb
@@ -2,9 +2,11 @@ cask "sapmachine11-jdk" do
   version "11.0.15.0.1"
   sha256 "3f61d992efc8bf53d56338a4b1ae0e00ff5ee3ef8c449a2c563de81cbbf0b336"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"

--- a/Casks/sapmachine11-jre.rb
+++ b/Casks/sapmachine11-jre.rb
@@ -1,14 +1,13 @@
-
-cask 'sapmachine11-jre' do
-  version '11.0.15.0.1'
-  sha256 'bcd12c1b28bb571a164804a016d9c4dbc79bf5777fdd525f10ac4f7818b9328d'
+cask "sapmachine11-jre" do
+  version "11.0.15.0.1"
+  sha256 "bcd12c1b28bb571a164804a016d9c4dbc79bf5777fdd525f10ac4f7818b9328d"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine11-jre.rb
+++ b/Casks/sapmachine11-jre.rb
@@ -2,9 +2,11 @@ cask "sapmachine11-jre" do
   version "11.0.15.0.1"
   sha256 "bcd12c1b28bb571a164804a016d9c4dbc79bf5777fdd525f10ac4f7818b9328d"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"

--- a/Casks/sapmachine12-ea-jdk.rb
+++ b/Casks/sapmachine12-ea-jdk.rb
@@ -2,9 +2,11 @@ cask "sapmachine12-ea-jdk" do
   version "12.0.2,9"
   sha256 "b401f92deb8d6c60c9324019fd628b900b4c0862bffbe712fc4757e8b2141466"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.tar.gz"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.tar.gz",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"

--- a/Casks/sapmachine12-ea-jdk.rb
+++ b/Casks/sapmachine12-ea-jdk.rb
@@ -1,14 +1,13 @@
+cask "sapmachine12-ea-jdk" do
+  version "12.0.2,9"
+  sha256 "b401f92deb8d6c60c9324019fd628b900b4c0862bffbe712fc4757e8b2141466"
 
-cask 'sapmachine12-ea-jdk' do
-  version '12.0.2,9'
-  sha256 'b401f92deb8d6c60c9324019fd628b900b4c0862bffbe712fc4757e8b2141466'
-
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.tar.gz"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.tar.gz"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine12-ea-jre.rb
+++ b/Casks/sapmachine12-ea-jre.rb
@@ -2,9 +2,11 @@ cask "sapmachine12-ea-jre" do
   version "12.0.2,9"
   sha256 "0e92892eaf693e5dca6cd6e6f65cca7249e361f79b77cf2fa045b8fd8f87b846"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.tar.gz"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.tar.gz",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"

--- a/Casks/sapmachine12-ea-jre.rb
+++ b/Casks/sapmachine12-ea-jre.rb
@@ -1,14 +1,13 @@
+cask "sapmachine12-ea-jre" do
+  version "12.0.2,9"
+  sha256 "0e92892eaf693e5dca6cd6e6f65cca7249e361f79b77cf2fa045b8fd8f87b846"
 
-cask 'sapmachine12-ea-jre' do
-  version '12.0.2,9'
-  sha256 '0e92892eaf693e5dca6cd6e6f65cca7249e361f79b77cf2fa045b8fd8f87b846'
-
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.tar.gz"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.tar.gz"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine12-jdk.rb
+++ b/Casks/sapmachine12-jdk.rb
@@ -2,9 +2,11 @@ cask "sapmachine12-jdk" do
   version "12.0.2"
   sha256 "ede180009ded8bef782e41ad72bd242faa6749ac889297c01777559278fc4848"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.tar.gz"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.tar.gz",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"

--- a/Casks/sapmachine12-jdk.rb
+++ b/Casks/sapmachine12-jdk.rb
@@ -1,14 +1,13 @@
-
-cask 'sapmachine12-jdk' do
-  version '12.0.2'
-  sha256 'ede180009ded8bef782e41ad72bd242faa6749ac889297c01777559278fc4848'
+cask "sapmachine12-jdk" do
+  version "12.0.2"
+  sha256 "ede180009ded8bef782e41ad72bd242faa6749ac889297c01777559278fc4848"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.tar.gz"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine12-jre.rb
+++ b/Casks/sapmachine12-jre.rb
@@ -1,14 +1,13 @@
-
-cask 'sapmachine12-jre' do
-  version '12.0.2'
-  sha256 '91f62145fa53771a3f3971dcb0ead4837dc534c9c62badc5fff51c7ad42a5a29'
+cask "sapmachine12-jre" do
+  version "12.0.2"
+  sha256 "91f62145fa53771a3f3971dcb0ead4837dc534c9c62badc5fff51c7ad42a5a29"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.tar.gz"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine12-jre.rb
+++ b/Casks/sapmachine12-jre.rb
@@ -2,9 +2,11 @@ cask "sapmachine12-jre" do
   version "12.0.2"
   sha256 "91f62145fa53771a3f3971dcb0ead4837dc534c9c62badc5fff51c7ad42a5a29"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.tar.gz"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.tar.gz",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"

--- a/Casks/sapmachine13-ea-jdk.rb
+++ b/Casks/sapmachine13-ea-jdk.rb
@@ -2,9 +2,11 @@ cask "sapmachine13-ea-jdk" do
   version "13.0.2,8"
   sha256 "aa56b511b0dc70bfd2334035a9bf68e02401325dda5d84a938ee51560dbab7ee"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"

--- a/Casks/sapmachine13-ea-jdk.rb
+++ b/Casks/sapmachine13-ea-jdk.rb
@@ -1,14 +1,13 @@
+cask "sapmachine13-ea-jdk" do
+  version "13.0.2,8"
+  sha256 "aa56b511b0dc70bfd2334035a9bf68e02401325dda5d84a938ee51560dbab7ee"
 
-cask 'sapmachine13-ea-jdk' do
-  version '13.0.2,8'
-  sha256 'aa56b511b0dc70bfd2334035a9bf68e02401325dda5d84a938ee51560dbab7ee'
-
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine13-ea-jre.rb
+++ b/Casks/sapmachine13-ea-jre.rb
@@ -2,9 +2,11 @@ cask "sapmachine13-ea-jre" do
   version "13.0.2,8"
   sha256 "68de5d566fd4bd7512d1318a807b2027322d50e0bdcd5253332c069141009e61"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"

--- a/Casks/sapmachine13-ea-jre.rb
+++ b/Casks/sapmachine13-ea-jre.rb
@@ -1,14 +1,13 @@
+cask "sapmachine13-ea-jre" do
+  version "13.0.2,8"
+  sha256 "68de5d566fd4bd7512d1318a807b2027322d50e0bdcd5253332c069141009e61"
 
-cask 'sapmachine13-ea-jre' do
-  version '13.0.2,8'
-  sha256 '68de5d566fd4bd7512d1318a807b2027322d50e0bdcd5253332c069141009e61'
-
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine13-jdk.rb
+++ b/Casks/sapmachine13-jdk.rb
@@ -2,9 +2,11 @@ cask "sapmachine13-jdk" do
   version "13.0.2"
   sha256 "12f84ff3f5be670520a404024b2d6eb9eec6bd9197b478bbd0af88faed25b48d"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"

--- a/Casks/sapmachine13-jdk.rb
+++ b/Casks/sapmachine13-jdk.rb
@@ -1,14 +1,13 @@
-
-cask 'sapmachine13-jdk' do
-  version '13.0.2'
-  sha256 '12f84ff3f5be670520a404024b2d6eb9eec6bd9197b478bbd0af88faed25b48d'
+cask "sapmachine13-jdk" do
+  version "13.0.2"
+  sha256 "12f84ff3f5be670520a404024b2d6eb9eec6bd9197b478bbd0af88faed25b48d"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine13-jre.rb
+++ b/Casks/sapmachine13-jre.rb
@@ -1,14 +1,13 @@
-
-cask 'sapmachine13-jre' do
-  version '13.0.2'
-  sha256 '9258f1c497ec97ed0ef1341c661a2277f1e1d3aba8bcece8ad8d283441e37cc2'
+cask "sapmachine13-jre" do
+  version "13.0.2"
+  sha256 "9258f1c497ec97ed0ef1341c661a2277f1e1d3aba8bcece8ad8d283441e37cc2"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine13-jre.rb
+++ b/Casks/sapmachine13-jre.rb
@@ -2,9 +2,11 @@ cask "sapmachine13-jre" do
   version "13.0.2"
   sha256 "9258f1c497ec97ed0ef1341c661a2277f1e1d3aba8bcece8ad8d283441e37cc2"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"

--- a/Casks/sapmachine14-ea-jdk.rb
+++ b/Casks/sapmachine14-ea-jdk.rb
@@ -2,9 +2,11 @@ cask "sapmachine14-ea-jdk" do
   version "14.0.2,12"
   sha256 "4ee49ee684a2479e7bd5ae7b18184585d4a380d0a68db98e0507af2b2750dee2"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"

--- a/Casks/sapmachine14-ea-jdk.rb
+++ b/Casks/sapmachine14-ea-jdk.rb
@@ -1,14 +1,13 @@
+cask "sapmachine14-ea-jdk" do
+  version "14.0.2,12"
+  sha256 "4ee49ee684a2479e7bd5ae7b18184585d4a380d0a68db98e0507af2b2750dee2"
 
-cask 'sapmachine14-ea-jdk' do
-  version '14.0.2,12'
-  sha256 '4ee49ee684a2479e7bd5ae7b18184585d4a380d0a68db98e0507af2b2750dee2'
-
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine14-ea-jre.rb
+++ b/Casks/sapmachine14-ea-jre.rb
@@ -1,14 +1,13 @@
+cask "sapmachine14-ea-jre" do
+  version "14.0.2,12"
+  sha256 "4b6472b00a69bf4cf48a66b601165e24ab241dbad8757599a9d6940352023e91"
 
-cask 'sapmachine14-ea-jre' do
-  version '14.0.2,12'
-  sha256 '4b6472b00a69bf4cf48a66b601165e24ab241dbad8757599a9d6940352023e91'
-
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine14-ea-jre.rb
+++ b/Casks/sapmachine14-ea-jre.rb
@@ -2,9 +2,11 @@ cask "sapmachine14-ea-jre" do
   version "14.0.2,12"
   sha256 "4b6472b00a69bf4cf48a66b601165e24ab241dbad8757599a9d6940352023e91"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"

--- a/Casks/sapmachine14-jdk.rb
+++ b/Casks/sapmachine14-jdk.rb
@@ -2,9 +2,11 @@ cask "sapmachine14-jdk" do
   version "14.0.2"
   sha256 "9c11682ba91c4285f8ca56682114a46c2e0bf723b65b81060b6f8403d681ff1f"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"

--- a/Casks/sapmachine14-jdk.rb
+++ b/Casks/sapmachine14-jdk.rb
@@ -1,14 +1,13 @@
-
-cask 'sapmachine14-jdk' do
-  version '14.0.2'
-  sha256 '9c11682ba91c4285f8ca56682114a46c2e0bf723b65b81060b6f8403d681ff1f'
+cask "sapmachine14-jdk" do
+  version "14.0.2"
+  sha256 "9c11682ba91c4285f8ca56682114a46c2e0bf723b65b81060b6f8403d681ff1f"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine14-jre.rb
+++ b/Casks/sapmachine14-jre.rb
@@ -1,14 +1,13 @@
-
-cask 'sapmachine14-jre' do
-  version '14.0.2'
-  sha256 '83539946edc09895c149d1e9a0a766a2a0e86739aad46a265b1592de63fb820c'
+cask "sapmachine14-jre" do
+  version "14.0.2"
+  sha256 "83539946edc09895c149d1e9a0a766a2a0e86739aad46a265b1592de63fb820c"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine14-jre.rb
+++ b/Casks/sapmachine14-jre.rb
@@ -2,9 +2,11 @@ cask "sapmachine14-jre" do
   version "14.0.2"
   sha256 "83539946edc09895c149d1e9a0a766a2a0e86739aad46a265b1592de63fb820c"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"

--- a/Casks/sapmachine15-ea-jdk.rb
+++ b/Casks/sapmachine15-ea-jdk.rb
@@ -1,14 +1,13 @@
+cask "sapmachine15-ea-jdk" do
+  version "15.0.2,7"
+  sha256 "8e07ded382a0d0a6e36b96ca339b9d1c34442b19605b6998c3604c429c1f5635"
 
-cask 'sapmachine15-ea-jdk' do
-  version '15.0.2,7'
-  sha256 '8e07ded382a0d0a6e36b96ca339b9d1c34442b19605b6998c3604c429c1f5635'
-
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine15-ea-jdk.rb
+++ b/Casks/sapmachine15-ea-jdk.rb
@@ -2,9 +2,11 @@ cask "sapmachine15-ea-jdk" do
   version "15.0.2,7"
   sha256 "8e07ded382a0d0a6e36b96ca339b9d1c34442b19605b6998c3604c429c1f5635"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"

--- a/Casks/sapmachine15-ea-jre.rb
+++ b/Casks/sapmachine15-ea-jre.rb
@@ -1,14 +1,13 @@
+cask "sapmachine15-ea-jre" do
+  version "15.0.2,7"
+  sha256 "6d977f4ee83a5b866a78b5d61660476fb4d359132558cf8017bc4da5a21138c3"
 
-cask 'sapmachine15-ea-jre' do
-  version '15.0.2,7'
-  sha256 '6d977f4ee83a5b866a78b5d61660476fb4d359132558cf8017bc4da5a21138c3'
-
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine15-ea-jre.rb
+++ b/Casks/sapmachine15-ea-jre.rb
@@ -2,9 +2,11 @@ cask "sapmachine15-ea-jre" do
   version "15.0.2,7"
   sha256 "6d977f4ee83a5b866a78b5d61660476fb4d359132558cf8017bc4da5a21138c3"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"

--- a/Casks/sapmachine15-jdk.rb
+++ b/Casks/sapmachine15-jdk.rb
@@ -2,9 +2,11 @@ cask "sapmachine15-jdk" do
   version "15.0.2"
   sha256 "35fd651595cac2588de08a943e8bb61ee2dd10146f4b459511ae577e9c3fa42c"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"

--- a/Casks/sapmachine15-jdk.rb
+++ b/Casks/sapmachine15-jdk.rb
@@ -1,14 +1,13 @@
-
-cask 'sapmachine15-jdk' do
-  version '15.0.2'
-  sha256 '35fd651595cac2588de08a943e8bb61ee2dd10146f4b459511ae577e9c3fa42c'
+cask "sapmachine15-jdk" do
+  version "15.0.2"
+  sha256 "35fd651595cac2588de08a943e8bb61ee2dd10146f4b459511ae577e9c3fa42c"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine15-jre.rb
+++ b/Casks/sapmachine15-jre.rb
@@ -2,9 +2,11 @@ cask "sapmachine15-jre" do
   version "15.0.2"
   sha256 "61be4d4d557384d4b7221861c920e1b120df830a23c221bf7d1c311d4c9ba438"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"

--- a/Casks/sapmachine15-jre.rb
+++ b/Casks/sapmachine15-jre.rb
@@ -1,14 +1,13 @@
-
-cask 'sapmachine15-jre' do
-  version '15.0.2'
-  sha256 '61be4d4d557384d4b7221861c920e1b120df830a23c221bf7d1c311d4c9ba438'
+cask "sapmachine15-jre" do
+  version "15.0.2"
+  sha256 "61be4d4d557384d4b7221861c920e1b120df830a23c221bf7d1c311d4c9ba438"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine16-ea-jdk.rb
+++ b/Casks/sapmachine16-ea-jdk.rb
@@ -2,9 +2,11 @@ cask "sapmachine16-ea-jdk" do
   version "16.0.2,7"
   sha256 "c486ed86d3b57d605eb1ad36ed13e03df805ff6b0e8009bfb8f13b94308e10b8"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"

--- a/Casks/sapmachine16-ea-jdk.rb
+++ b/Casks/sapmachine16-ea-jdk.rb
@@ -1,14 +1,13 @@
+cask "sapmachine16-ea-jdk" do
+  version "16.0.2,7"
+  sha256 "c486ed86d3b57d605eb1ad36ed13e03df805ff6b0e8009bfb8f13b94308e10b8"
 
-cask 'sapmachine16-ea-jdk' do
-  version '16.0.2,7'
-  sha256 'c486ed86d3b57d605eb1ad36ed13e03df805ff6b0e8009bfb8f13b94308e10b8'
-
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jdk-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine16-ea-jre.rb
+++ b/Casks/sapmachine16-ea-jre.rb
@@ -2,9 +2,11 @@ cask "sapmachine16-ea-jre" do
   version "16.0.2,7"
   sha256 "c231cdf03657678907c0902b8f2c454cb9f3365703bb23659589cb6c1145a12b"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"

--- a/Casks/sapmachine16-ea-jre.rb
+++ b/Casks/sapmachine16-ea-jre.rb
@@ -1,14 +1,13 @@
+cask "sapmachine16-ea-jre" do
+  version "16.0.2,7"
+  sha256 "c231cdf03657678907c0902b8f2c454cb9f3365703bb23659589cb6c1145a12b"
 
-cask 'sapmachine16-ea-jre' do
-  version '16.0.2,7'
-  sha256 'c231cdf03657678907c0902b8f2c454cb9f3365703bb23659589cb6c1145a12b'
-
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.csv.first}%2B#{version.csv.second}/sapmachine-jre-#{version.csv.first}-ea.#{version.csv.second}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine16-jdk.rb
+++ b/Casks/sapmachine16-jdk.rb
@@ -2,9 +2,11 @@ cask "sapmachine16-jdk" do
   version "16.0.2"
   sha256 "d385e29399a35156ecaa23fbeed08b876c4b9bfcf076640169bde95196ee1d78"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"

--- a/Casks/sapmachine16-jdk.rb
+++ b/Casks/sapmachine16-jdk.rb
@@ -1,14 +1,13 @@
-
-cask 'sapmachine16-jdk' do
-  version '16.0.2'
-  sha256 'd385e29399a35156ecaa23fbeed08b876c4b9bfcf076640169bde95196ee1d78'
+cask "sapmachine16-jdk" do
+  version "16.0.2"
+  sha256 "d385e29399a35156ecaa23fbeed08b876c4b9bfcf076640169bde95196ee1d78"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine16-jre.rb
+++ b/Casks/sapmachine16-jre.rb
@@ -1,14 +1,13 @@
-
-cask 'sapmachine16-jre' do
-  version '16.0.2'
-  sha256 '728fef2bb383a788e6b34b9fe962f833802b0c02d2001ec51ca01b970ac1e149'
+cask "sapmachine16-jre" do
+  version "16.0.2"
+  sha256 "728fef2bb383a788e6b34b9fe962f833802b0c02d2001ec51ca01b970ac1e149"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine16-jre.rb
+++ b/Casks/sapmachine16-jre.rb
@@ -2,9 +2,11 @@ cask "sapmachine16-jre" do
   version "16.0.2"
   sha256 "728fef2bb383a788e6b34b9fe962f833802b0c02d2001ec51ca01b970ac1e149"
 
-  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
+  url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg",
+      verified: "https://github.com/SAP/SapMachine"
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"

--- a/Casks/sapmachine17-ea-jdk.rb
+++ b/Casks/sapmachine17-ea-jdk.rb
@@ -2,15 +2,18 @@ cask "sapmachine17-ea-jdk" do
   version "17.0.4,4"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "b0194330ba41eae75bbc461be5b06fac31a92f23078931fdbe5feee39a3ca98e"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "3fe3f207cea2e1b78ff61c8c2cb863c0e27becc087499ad8cfeb979b4b0cc018"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"

--- a/Casks/sapmachine17-ea-jdk.rb
+++ b/Casks/sapmachine17-ea-jdk.rb
@@ -1,20 +1,19 @@
-
-cask 'sapmachine17-ea-jdk' do
-  version '17.0.4,4'
+cask "sapmachine17-ea-jdk" do
+  version "17.0.4,4"
 
   if Hardware::CPU.intel?
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
-    sha256 'b0194330ba41eae75bbc461be5b06fac31a92f23078931fdbe5feee39a3ca98e'
+    sha256 "b0194330ba41eae75bbc461be5b06fac31a92f23078931fdbe5feee39a3ca98e"
   else
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
-    sha256 '3fe3f207cea2e1b78ff61c8c2cb863c0e27becc087499ad8cfeb979b4b0cc018'
+    sha256 "3fe3f207cea2e1b78ff61c8c2cb863c0e27becc087499ad8cfeb979b4b0cc018"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine17-ea-jre.rb
+++ b/Casks/sapmachine17-ea-jre.rb
@@ -2,15 +2,18 @@ cask "sapmachine17-ea-jre" do
   version "17.0.4,4"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "efd417b1efe96b62b81664f121ccf40d9e40010ed5942f01200bde8acf62b1b5"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "c640a282bf8ab1a4839c4ae13aa2ee075b57eb50920a20315a08eeec56809a23"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"

--- a/Casks/sapmachine17-ea-jre.rb
+++ b/Casks/sapmachine17-ea-jre.rb
@@ -1,20 +1,19 @@
-
-cask 'sapmachine17-ea-jre' do
-  version '17.0.4,4'
+cask "sapmachine17-ea-jre" do
+  version "17.0.4,4"
 
   if Hardware::CPU.intel?
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
-    sha256 'efd417b1efe96b62b81664f121ccf40d9e40010ed5942f01200bde8acf62b1b5'
+    sha256 "efd417b1efe96b62b81664f121ccf40d9e40010ed5942f01200bde8acf62b1b5"
   else
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
-    sha256 'c640a282bf8ab1a4839c4ae13aa2ee075b57eb50920a20315a08eeec56809a23'
+    sha256 "c640a282bf8ab1a4839c4ae13aa2ee075b57eb50920a20315a08eeec56809a23"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine17-jdk.rb
+++ b/Casks/sapmachine17-jdk.rb
@@ -1,20 +1,19 @@
-
-cask 'sapmachine17-jdk' do
-  version '17.0.3.0.1'
+cask "sapmachine17-jdk" do
+  version "17.0.3.0.1"
 
   if Hardware::CPU.intel?
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-x64_bin.dmg"
-    sha256 '665932b8f9f7fccef703705f9b7c962730d9a04d2481c4da19ccc11a28f23492'
+    sha256 "665932b8f9f7fccef703705f9b7c962730d9a04d2481c4da19ccc11a28f23492"
   else
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-aarch64_bin.dmg"
-    sha256 'ef1caa159f4c15e54dbf30fd6cd6665cc455f93c4ab7b40e019923103428cb69'
+    sha256 "ef1caa159f4c15e54dbf30fd6cd6665cc455f93c4ab7b40e019923103428cb69"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine17-jdk.rb
+++ b/Casks/sapmachine17-jdk.rb
@@ -2,15 +2,18 @@ cask "sapmachine17-jdk" do
   version "17.0.3.0.1"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-x64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-x64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "665932b8f9f7fccef703705f9b7c962730d9a04d2481c4da19ccc11a28f23492"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-aarch64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-aarch64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "ef1caa159f4c15e54dbf30fd6cd6665cc455f93c4ab7b40e019923103428cb69"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"

--- a/Casks/sapmachine17-jre.rb
+++ b/Casks/sapmachine17-jre.rb
@@ -1,20 +1,19 @@
-
-cask 'sapmachine17-jre' do
-  version '17.0.3.0.1'
+cask "sapmachine17-jre" do
+  version "17.0.3.0.1"
 
   if Hardware::CPU.intel?
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_macos-x64_bin.dmg"
-    sha256 'fdf88e534d1f151b1f30c15471a1a064e9f7f373dfff435420fd1dec5f015861'
+    sha256 "fdf88e534d1f151b1f30c15471a1a064e9f7f373dfff435420fd1dec5f015861"
   else
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_macos-aarch64_bin.dmg"
-    sha256 'db05fef84a8e7d69dd791c2866d122cccb89349e1ff79da8e5eab6f513f72c08'
+    sha256 "db05fef84a8e7d69dd791c2866d122cccb89349e1ff79da8e5eab6f513f72c08"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine17-jre.rb
+++ b/Casks/sapmachine17-jre.rb
@@ -2,15 +2,18 @@ cask "sapmachine17-jre" do
   version "17.0.3.0.1"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_macos-x64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_macos-x64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "fdf88e534d1f151b1f30c15471a1a064e9f7f373dfff435420fd1dec5f015861"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_macos-aarch64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_macos-aarch64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "db05fef84a8e7d69dd791c2866d122cccb89349e1ff79da8e5eab6f513f72c08"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"

--- a/Casks/sapmachine18-ea-jdk.rb
+++ b/Casks/sapmachine18-ea-jdk.rb
@@ -1,20 +1,19 @@
-
-cask 'sapmachine18-ea-jdk' do
-  version '18.0.1.1,2'
+cask "sapmachine18-ea-jdk" do
+  version "18.0.1.1,2"
 
   if Hardware::CPU.intel?
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
-    sha256 'd1e322b0c0921ee352e31297d966371731d30612248a029ed1b2537f2a9153f5'
+    sha256 "d1e322b0c0921ee352e31297d966371731d30612248a029ed1b2537f2a9153f5"
   else
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
-    sha256 '46826307e35729a2281560f69ce8c3343c034e0094d690ee900c5bad3cefc6d4'
+    sha256 "46826307e35729a2281560f69ce8c3343c034e0094d690ee900c5bad3cefc6d4"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine18-ea-jdk.rb
+++ b/Casks/sapmachine18-ea-jdk.rb
@@ -2,15 +2,18 @@ cask "sapmachine18-ea-jdk" do
   version "18.0.1.1,2"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "d1e322b0c0921ee352e31297d966371731d30612248a029ed1b2537f2a9153f5"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "46826307e35729a2281560f69ce8c3343c034e0094d690ee900c5bad3cefc6d4"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"

--- a/Casks/sapmachine18-ea-jre.rb
+++ b/Casks/sapmachine18-ea-jre.rb
@@ -1,20 +1,19 @@
-
-cask 'sapmachine18-ea-jre' do
-  version '18.0.1.1,2'
+cask "sapmachine18-ea-jre" do
+  version "18.0.1.1,2"
 
   if Hardware::CPU.intel?
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
-    sha256 'd0fc2471a4028cc2018cffe0a17c646b2e0177d4972bcb81d9cb6857142bb4f7'
+    sha256 "d0fc2471a4028cc2018cffe0a17c646b2e0177d4972bcb81d9cb6857142bb4f7"
   else
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
-    sha256 '5b6693afd16a021a6f263fb6c63072f9e6d125a258fc1726bab18ac78c050ed1'
+    sha256 "5b6693afd16a021a6f263fb6c63072f9e6d125a258fc1726bab18ac78c050ed1"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine18-ea-jre.rb
+++ b/Casks/sapmachine18-ea-jre.rb
@@ -2,15 +2,18 @@ cask "sapmachine18-ea-jre" do
   version "18.0.1.1,2"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "d0fc2471a4028cc2018cffe0a17c646b2e0177d4972bcb81d9cb6857142bb4f7"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "5b6693afd16a021a6f263fb6c63072f9e6d125a258fc1726bab18ac78c050ed1"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"

--- a/Casks/sapmachine18-jdk.rb
+++ b/Casks/sapmachine18-jdk.rb
@@ -1,20 +1,19 @@
-
-cask 'sapmachine18-jdk' do
-  version '18.0.1.1'
+cask "sapmachine18-jdk" do
+  version "18.0.1.1"
 
   if Hardware::CPU.intel?
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-x64_bin.dmg"
-    sha256 'e26be90ec536d7f1f24a048ab289ec36829cc6d6fc67d113423b051bcbd76ee7'
+    sha256 "e26be90ec536d7f1f24a048ab289ec36829cc6d6fc67d113423b051bcbd76ee7"
   else
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-aarch64_bin.dmg"
-    sha256 '0b0fd7590ae9a7ef1a9c50474d711bb994ce2fe1172c94088f0541b9cf941e57'
+    sha256 "0b0fd7590ae9a7ef1a9c50474d711bb994ce2fe1172c94088f0541b9cf941e57"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine18-jdk.rb
+++ b/Casks/sapmachine18-jdk.rb
@@ -2,15 +2,18 @@ cask "sapmachine18-jdk" do
   version "18.0.1.1"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-x64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-x64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "e26be90ec536d7f1f24a048ab289ec36829cc6d6fc67d113423b051bcbd76ee7"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-aarch64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-aarch64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "0b0fd7590ae9a7ef1a9c50474d711bb994ce2fe1172c94088f0541b9cf941e57"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jdk"

--- a/Casks/sapmachine18-jre.rb
+++ b/Casks/sapmachine18-jre.rb
@@ -2,15 +2,18 @@ cask "sapmachine18-jre" do
   version "18.0.1.1"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_macos-x64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_macos-x64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "a786f86029ea90f0e2d74bc1fc5096e63813f90fbc8839e6b248f457fb3b8177"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_macos-aarch64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_macos-aarch64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "1779b501f404c106a28bb4873c08207c750cac659d2bf44df49d955f1ecb7fe1"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"

--- a/Casks/sapmachine18-jre.rb
+++ b/Casks/sapmachine18-jre.rb
@@ -1,20 +1,19 @@
-
-cask 'sapmachine18-jre' do
-  version '18.0.1.1'
+cask "sapmachine18-jre" do
+  version "18.0.1.1"
 
   if Hardware::CPU.intel?
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_macos-x64_bin.dmg"
-    sha256 'a786f86029ea90f0e2d74bc1fc5096e63813f90fbc8839e6b248f457fb3b8177'
+    sha256 "a786f86029ea90f0e2d74bc1fc5096e63813f90fbc8839e6b248f457fb3b8177"
   else
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_macos-aarch64_bin.dmg"
-    sha256 '1779b501f404c106a28bb4873c08207c750cac659d2bf44df49d955f1ecb7fe1'
+    sha256 "1779b501f404c106a28bb4873c08207c750cac659d2bf44df49d955f1ecb7fe1"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine19-ea-jdk.rb
+++ b/Casks/sapmachine19-ea-jdk.rb
@@ -2,15 +2,18 @@ cask "sapmachine19-ea-jdk" do
   version "19,24"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "5537fdc264f1be60a650c0f165156d01a4fe8060285cd479bc64d6c65f1c565c"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "595c23805a59e3e6489f1e09be904f58abfb7a71ab8026162b1031eca2860ffe"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"

--- a/Casks/sapmachine19-ea-jdk.rb
+++ b/Casks/sapmachine19-ea-jdk.rb
@@ -1,20 +1,19 @@
-
-cask 'sapmachine19-ea-jdk' do
-  version '19,24'
+cask "sapmachine19-ea-jdk" do
+  version "19,24"
 
   if Hardware::CPU.intel?
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
-    sha256 '5537fdc264f1be60a650c0f165156d01a4fe8060285cd479bc64d6c65f1c565c'
+    sha256 "5537fdc264f1be60a650c0f165156d01a4fe8060285cd479bc64d6c65f1c565c"
   else
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
-    sha256 '595c23805a59e3e6489f1e09be904f58abfb7a71ab8026162b1031eca2860ffe'
+    sha256 "595c23805a59e3e6489f1e09be904f58abfb7a71ab8026162b1031eca2860ffe"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jdk"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end

--- a/Casks/sapmachine19-ea-jdk.rb
+++ b/Casks/sapmachine19-ea-jdk.rb
@@ -2,11 +2,11 @@ cask "sapmachine19-ea-jdk" do
   version "19,24"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg",
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-snapshot_macos-x64_bin.dmg",
         verified: "https://github.com/SAP/SapMachine"
     sha256 "5537fdc264f1be60a650c0f165156d01a4fe8060285cd479bc64d6c65f1c565c"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg",
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-snapshot_macos-aarch64_bin.dmg",
         verified: "https://github.com/SAP/SapMachine"
     sha256 "595c23805a59e3e6489f1e09be904f58abfb7a71ab8026162b1031eca2860ffe"
   end

--- a/Casks/sapmachine19-ea-jre.rb
+++ b/Casks/sapmachine19-ea-jre.rb
@@ -2,15 +2,18 @@ cask "sapmachine19-ea-jre" do
   version "19,24"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "d89ddee8d0cf101a0daa6a620c97aa845b84b0ea645eb79ff20bdcbed7903096"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg",
+        verified: "https://github.com/SAP/SapMachine"
     sha256 "a435763a6410c26de9967a2300109b59ee60d38052d2117a14af336793431fd3"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
+  desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"

--- a/Casks/sapmachine19-ea-jre.rb
+++ b/Casks/sapmachine19-ea-jre.rb
@@ -2,11 +2,11 @@ cask "sapmachine19-ea-jre" do
   version "19,24"
 
   if Hardware::CPU.intel?
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg",
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-snapshot_macos-x64_bin.dmg",
         verified: "https://github.com/SAP/SapMachine"
     sha256 "d89ddee8d0cf101a0daa6a620c97aa845b84b0ea645eb79ff20bdcbed7903096"
   else
-    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg",
+    url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-snapshot_macos-aarch64_bin.dmg",
         verified: "https://github.com/SAP/SapMachine"
     sha256 "a435763a6410c26de9967a2300109b59ee60d38052d2117a14af336793431fd3"
   end

--- a/Casks/sapmachine19-ea-jre.rb
+++ b/Casks/sapmachine19-ea-jre.rb
@@ -1,20 +1,19 @@
-
-cask 'sapmachine19-ea-jre' do
-  version '19,24'
+cask "sapmachine19-ea-jre" do
+  version "19,24"
 
   if Hardware::CPU.intel?
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-x64_bin.dmg"
-    sha256 'd89ddee8d0cf101a0daa6a620c97aa845b84b0ea645eb79ff20bdcbed7903096'
+    sha256 "d89ddee8d0cf101a0daa6a620c97aa845b84b0ea645eb79ff20bdcbed7903096"
   else
     url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_macos-aarch64_bin.dmg"
-    sha256 'a435763a6410c26de9967a2300109b59ee60d38052d2117a14af336793431fd3'
+    sha256 "a435763a6410c26de9967a2300109b59ee60d38052d2117a14af336793431fd3"
   end
 
   appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
-  name 'SapMachine OpenJDK Development Kit'
-  homepage 'https://sapmachine.io/'
+  name "SapMachine OpenJDK Development Kit"
+  homepage "https://sapmachine.io/"
 
   artifact "sapmachine-jre-#{version.before_comma}.jre", target: "/Library/Java/JavaVirtualMachines/sapmachine-#{version.major}-ea.jre"
 
-  uninstall rmdir: '/Library/Java/JavaVirtualMachines'
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines"
 end


### PR DESCRIPTION
This resolves *almost* all audit failures on all casks; the only ones remaining are because some of the casks point to prerelease versions by nature, and audit doesn't like that.  This also fixes installation errors due to using the wrong URLs on the most recent 19-ea versions.