### PR TITLE
Delete `appcast` stanzas

### DIFF
--- a/Casks/sapmachine11-ea-jdk.rb
+++ b/Casks/sapmachine11-ea-jdk.rb
@@ -12,7 +12,6 @@ cask "sapmachine11-ea-jdk" do
     sha256 "ba755996010f19993493733f222a0d7e20f7cfba4fabbf4d453e887943ce8aaf"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine11-ea-jre.rb
+++ b/Casks/sapmachine11-ea-jre.rb
@@ -12,7 +12,6 @@ cask "sapmachine11-ea-jre" do
     sha256 "9ab2db1059c78735ad4b04529671e7b6ea7c15da2e590b4b7aafde29b63cfb36"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine11-jdk.rb
+++ b/Casks/sapmachine11-jdk.rb
@@ -12,7 +12,6 @@ cask "sapmachine11-jdk" do
     sha256 "90876d2396dece12bab4f1058a45252db371ace05fc4c08ac7b14a3f74115d19"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine11-jre.rb
+++ b/Casks/sapmachine11-jre.rb
@@ -12,7 +12,6 @@ cask "sapmachine11-jre" do
     sha256 "135d11caa3d2199fa037cd10341f8f3cd068e583b74ac528902d072822ef400c"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine12-ea-jdk.rb
+++ b/Casks/sapmachine12-ea-jdk.rb
@@ -4,7 +4,6 @@ cask 'sapmachine12-ea-jdk' do
   sha256 'b401f92deb8d6c60c9324019fd628b900b4c0862bffbe712fc4757e8b2141466'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.tar.gz"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine12-ea-jre.rb
+++ b/Casks/sapmachine12-ea-jre.rb
@@ -4,7 +4,6 @@ cask 'sapmachine12-ea-jre' do
   sha256 '0e92892eaf693e5dca6cd6e6f65cca7249e361f79b77cf2fa045b8fd8f87b846'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.tar.gz"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine12-jdk.rb
+++ b/Casks/sapmachine12-jdk.rb
@@ -4,7 +4,6 @@ cask 'sapmachine12-jdk' do
   sha256 'ede180009ded8bef782e41ad72bd242faa6749ac889297c01777559278fc4848'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.tar.gz"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine12-jre.rb
+++ b/Casks/sapmachine12-jre.rb
@@ -4,7 +4,6 @@ cask 'sapmachine12-jre' do
   sha256 '91f62145fa53771a3f3971dcb0ead4837dc534c9c62badc5fff51c7ad42a5a29'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.tar.gz"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine13-ea-jdk.rb
+++ b/Casks/sapmachine13-ea-jdk.rb
@@ -4,7 +4,6 @@ cask 'sapmachine13-ea-jdk' do
   sha256 'aa56b511b0dc70bfd2334035a9bf68e02401325dda5d84a938ee51560dbab7ee'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine13-ea-jre.rb
+++ b/Casks/sapmachine13-ea-jre.rb
@@ -4,7 +4,6 @@ cask 'sapmachine13-ea-jre' do
   sha256 '68de5d566fd4bd7512d1318a807b2027322d50e0bdcd5253332c069141009e61'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine13-jdk.rb
+++ b/Casks/sapmachine13-jdk.rb
@@ -4,7 +4,6 @@ cask 'sapmachine13-jdk' do
   sha256 '12f84ff3f5be670520a404024b2d6eb9eec6bd9197b478bbd0af88faed25b48d'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine13-jre.rb
+++ b/Casks/sapmachine13-jre.rb
@@ -4,7 +4,6 @@ cask 'sapmachine13-jre' do
   sha256 '9258f1c497ec97ed0ef1341c661a2277f1e1d3aba8bcece8ad8d283441e37cc2'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine14-ea-jdk.rb
+++ b/Casks/sapmachine14-ea-jdk.rb
@@ -4,7 +4,6 @@ cask 'sapmachine14-ea-jdk' do
   sha256 '4ee49ee684a2479e7bd5ae7b18184585d4a380d0a68db98e0507af2b2750dee2'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine14-ea-jre.rb
+++ b/Casks/sapmachine14-ea-jre.rb
@@ -4,7 +4,6 @@ cask 'sapmachine14-ea-jre' do
   sha256 '4b6472b00a69bf4cf48a66b601165e24ab241dbad8757599a9d6940352023e91'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine14-jdk.rb
+++ b/Casks/sapmachine14-jdk.rb
@@ -4,7 +4,6 @@ cask 'sapmachine14-jdk' do
   sha256 '9c11682ba91c4285f8ca56682114a46c2e0bf723b65b81060b6f8403d681ff1f'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine14-jre.rb
+++ b/Casks/sapmachine14-jre.rb
@@ -4,7 +4,6 @@ cask 'sapmachine14-jre' do
   sha256 '83539946edc09895c149d1e9a0a766a2a0e86739aad46a265b1592de63fb820c'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine15-ea-jdk.rb
+++ b/Casks/sapmachine15-ea-jdk.rb
@@ -4,7 +4,6 @@ cask 'sapmachine15-ea-jdk' do
   sha256 '8e07ded382a0d0a6e36b96ca339b9d1c34442b19605b6998c3604c429c1f5635'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine15-ea-jre.rb
+++ b/Casks/sapmachine15-ea-jre.rb
@@ -4,7 +4,6 @@ cask 'sapmachine15-ea-jre' do
   sha256 '6d977f4ee83a5b866a78b5d61660476fb4d359132558cf8017bc4da5a21138c3'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine15-jdk.rb
+++ b/Casks/sapmachine15-jdk.rb
@@ -4,7 +4,6 @@ cask 'sapmachine15-jdk' do
   sha256 '35fd651595cac2588de08a943e8bb61ee2dd10146f4b459511ae577e9c3fa42c'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine15-jre.rb
+++ b/Casks/sapmachine15-jre.rb
@@ -4,7 +4,6 @@ cask 'sapmachine15-jre' do
   sha256 '61be4d4d557384d4b7221861c920e1b120df830a23c221bf7d1c311d4c9ba438'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine16-ea-jdk.rb
+++ b/Casks/sapmachine16-ea-jdk.rb
@@ -4,7 +4,6 @@ cask 'sapmachine16-ea-jdk' do
   sha256 'c486ed86d3b57d605eb1ad36ed13e03df805ff6b0e8009bfb8f13b94308e10b8'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jdk-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine16-ea-jre.rb
+++ b/Casks/sapmachine16-ea-jre.rb
@@ -4,7 +4,6 @@ cask 'sapmachine16-ea-jre' do
   sha256 'c231cdf03657678907c0902b8f2c454cb9f3365703bb23659589cb6c1145a12b'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version.before_comma}%2B#{version.after_comma}/sapmachine-jre-#{version.before_comma}-ea.#{version.after_comma}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine16-jdk.rb
+++ b/Casks/sapmachine16-jdk.rb
@@ -4,7 +4,6 @@ cask 'sapmachine16-jdk' do
   sha256 'd385e29399a35156ecaa23fbeed08b876c4b9bfcf076640169bde95196ee1d78'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine16-jre.rb
+++ b/Casks/sapmachine16-jre.rb
@@ -4,7 +4,6 @@ cask 'sapmachine16-jre' do
   sha256 '728fef2bb383a788e6b34b9fe962f833802b0c02d2001ec51ca01b970ac1e149'
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jre-#{version}_osx-x64_bin.dmg"
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name 'SapMachine OpenJDK Development Kit'
   homepage 'https://sapmachine.io/'
 

--- a/Casks/sapmachine17-ea-jdk.rb
+++ b/Casks/sapmachine17-ea-jdk.rb
@@ -12,7 +12,6 @@ cask "sapmachine17-ea-jdk" do
     sha256 "7754466405b6c77ddf6c22132711c3105b16cedd55a8ae3d1c1872b2ae73cc68"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine17-ea-jre.rb
+++ b/Casks/sapmachine17-ea-jre.rb
@@ -12,7 +12,6 @@ cask "sapmachine17-ea-jre" do
     sha256 "b319471ec2fef9fd7dfd73b1378fa6eef37b7ac1729f1c404a351804ac1aeaf9"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine17-jdk.rb
+++ b/Casks/sapmachine17-jdk.rb
@@ -12,7 +12,6 @@ cask "sapmachine17-jdk" do
     sha256 "ecaf8a1c2fe8fe2df00cba36c7c87678b9bf46d8428cffc66f7a1aa6b2c44883"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine17-jre.rb
+++ b/Casks/sapmachine17-jre.rb
@@ -12,7 +12,6 @@ cask "sapmachine17-jre" do
     sha256 "922b7f7ef71331653e7555f3ff584922b8faef45341cd1c4eab2509e1b4491c7"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine18-ea-jdk.rb
+++ b/Casks/sapmachine18-ea-jdk.rb
@@ -12,7 +12,6 @@ cask "sapmachine18-ea-jdk" do
     sha256 "4f01d304c51502a03472981fadfb370aa1eaa102d7e0cbaa5021448d090a59e2"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine18-ea-jre.rb
+++ b/Casks/sapmachine18-ea-jre.rb
@@ -12,7 +12,6 @@ cask "sapmachine18-ea-jre" do
     sha256 "bb83f000bf081c33775822bc8bca0b3f7c39250e3adcf848b2bbc7e2e1e2e4cc"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine18-jdk.rb
+++ b/Casks/sapmachine18-jdk.rb
@@ -12,7 +12,6 @@ cask "sapmachine18-jdk" do
     sha256 "1d43d404987b67fb5fa9667a4e22d01a48a79ed8a9fda52d1570414f81ba775b"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine18-jre.rb
+++ b/Casks/sapmachine18-jre.rb
@@ -12,7 +12,6 @@ cask "sapmachine18-jre" do
     sha256 "dbd19c2f1addb14357dc2f4cd40d3cc620646ed61760d2850e2cb8a586714e4b"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine19-ea-jdk.rb
+++ b/Casks/sapmachine19-ea-jdk.rb
@@ -12,7 +12,6 @@ cask "sapmachine19-ea-jdk" do
     sha256 "f7e685dd440591ce35ed34314337ab43c5306dfead0bfe9bc4bb77cf4d5e0b1b"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine19-ea-jre.rb
+++ b/Casks/sapmachine19-ea-jre.rb
@@ -12,7 +12,6 @@ cask "sapmachine19-ea-jre" do
     sha256 "21ecaea350cd4b8de7d2e9f82c0c0b9e8664f03c4dd92fb48f47a5b7d7b840eb"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine19-jdk.rb
+++ b/Casks/sapmachine19-jdk.rb
@@ -12,7 +12,6 @@ cask "sapmachine19-jdk" do
     sha256 "f354ef6ce50590330973c2b2ae53918ba6471bb1c1e89862dea4d18a9c7cfa9e"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine19-jre.rb
+++ b/Casks/sapmachine19-jre.rb
@@ -12,7 +12,6 @@ cask "sapmachine19-jre" do
     sha256 "99dfb9a5e9614e1d8ffde8cab718e4a03bd6e822bdb77652f3348ba0fc9d4c69"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine20-ea-jdk.rb
+++ b/Casks/sapmachine20-ea-jdk.rb
@@ -12,7 +12,6 @@ cask "sapmachine20-ea-jdk" do
     sha256 "9eec454b566e2e0b9476e9c661b5662f96d6fcdec8e8c36b00f9d0a09f8392df"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine20-ea-jre.rb
+++ b/Casks/sapmachine20-ea-jre.rb
@@ -12,7 +12,6 @@ cask "sapmachine20-ea-jre" do
     sha256 "8cbadb9ed42eabe426922f7b76c8d4b3d63908eb3648c53ad9bee02af3c81d84"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine20-jdk.rb
+++ b/Casks/sapmachine20-jdk.rb
@@ -12,7 +12,6 @@ cask "sapmachine20-jdk" do
     sha256 "75f85bfb4db30e73e7893703c8016c5a087d412cfb656ad5f89652ba432b0f7a"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine20-jre.rb
+++ b/Casks/sapmachine20-jre.rb
@@ -12,7 +12,6 @@ cask "sapmachine20-jre" do
     sha256 "2eec57e1919cc135b1d3020443a091e706476c562d2632e8964b21af3304d1e4"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine21-ea-jdk.rb
+++ b/Casks/sapmachine21-ea-jdk.rb
@@ -12,7 +12,6 @@ cask "sapmachine21-ea-jdk" do
     sha256 "fe7093d6f3ea4e4824122b4aa6c65e4d68275faee55f1d7e62c71ff2bf027015"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine21-ea-jre.rb
+++ b/Casks/sapmachine21-ea-jre.rb
@@ -12,7 +12,6 @@ cask "sapmachine21-ea-jre" do
     sha256 "f8fde4deffe64a6c6b7fed501d6b538e6e86e18591b1016e1489569fbda26712"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine22-ea-jdk.rb
+++ b/Casks/sapmachine22-ea-jdk.rb
@@ -12,7 +12,6 @@ cask "sapmachine22-ea-jdk" do
     sha256 "f5edcc3d36f8517b364bfc6f7989f0876c048f6c57b453adde5bb1def460785e"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"

--- a/Casks/sapmachine22-ea-jre.rb
+++ b/Casks/sapmachine22-ea-jre.rb
@@ -12,7 +12,6 @@ cask "sapmachine22-ea-jre" do
     sha256 "15a2237bbcacb2b281865871042335ccb2e7b2f12c97b807c2bca0e41603c8d9"
   end
 
-  appcast "https://sap.github.io/SapMachine/latest/#{version.major}"
   name "SapMachine OpenJDK Development Kit"
   desc "OpenJDK build from SAP"
   homepage "https://sapmachine.io/"


### PR DESCRIPTION
These have been deprecated for a while now, and have now started causing errors when attempting to use the casks.